### PR TITLE
Improve logging clarity and detail

### DIFF
--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -13,10 +13,17 @@ pub fn dirt(ctx: RetProbeContext) -> u32 {
 }
 
 fn try_dirt(ctx: RetProbeContext) -> Result<u32, u32> {
-    // Use both logging methods for debugging
-    info!(&ctx, "kretprobe called");
+    // Get process information
+    let pid = bpf_get_current_pid_tgid() >> 32;
+    let tgid = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
+    
+    // Log detailed return information
+    info!(&ctx, "DIRT: vfs_unlink RETURN - PID: {}, TGID: {}, Return Code: {}", 
+          pid, tgid, ctx.ret());
+    
     unsafe {
-        bpf_printk!(b"DIRT: kretprobe called on vfs_unlink return");
+        bpf_printk!(b"DIRT: vfs_unlink RETURN - PID: %d, TGID: %d, Return: %d", 
+                    pid, tgid, ctx.ret());
     }
     Ok(0)
 }
@@ -30,12 +37,58 @@ pub fn vfs_unlink_probe(ctx: ProbeContext) -> u32 {
 }
 
 fn try_vfs_unlink(ctx: ProbeContext) -> Result<u32, u32> {
-    // Use both logging methods for debugging
-    info!(&ctx, "vfs_unlink kprobe triggered - file being unlinked");
+    // Get process information
+    let pid = bpf_get_current_pid_tgid() >> 32;
+    let tgid = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
+    
+    // Get current task info
+    let task = bpf_get_current_task();
+    let comm = bpf_get_current_comm();
+    
+    // Log detailed entry information
+    info!(&ctx, "DIRT: vfs_unlink ENTRY - PID: {}, TGID: {}, Comm: {}, Task: {}", 
+          pid, tgid, comm, task);
+    
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink kprobe triggered - file being unlinked");
+        bpf_printk!(b"DIRT: vfs_unlink ENTRY - PID: %d, TGID: %d, Comm: %s", 
+                    pid, tgid, &comm);
     }
     Ok(0)
+}
+
+// Helper functions to get process information
+#[inline(always)]
+fn bpf_get_current_pid_tgid() -> u64 {
+    unsafe {
+        let mut pid_tgid: u64 = 0;
+        bpf_get_current_pid_tgid(&mut pid_tgid as *mut u64 as *mut core::ffi::c_void);
+        pid_tgid
+    }
+}
+
+#[inline(always)]
+fn bpf_get_current_task() -> u64 {
+    unsafe {
+        let mut task: u64 = 0;
+        bpf_get_current_task(&mut task as *mut u64 as *mut core::ffi::c_void);
+        task
+    }
+}
+
+#[inline(always)]
+fn bpf_get_current_comm() -> [u8; 16] {
+    unsafe {
+        let mut comm: [u8; 16] = [0; 16];
+        bpf_get_current_comm(&mut comm as *mut u8 as *mut core::ffi::c_void, 16);
+        comm
+    }
+}
+
+// BPF helper function declarations
+extern "C" {
+    fn bpf_get_current_pid_tgid(pid_tgid: *mut core::ffi::c_void) -> u64;
+    fn bpf_get_current_task(task: *mut core::ffi::c_void) -> u64;
+    fn bpf_get_current_comm(buf: *mut core::ffi::c_void, size: u32) -> i32;
 }
 
 #[cfg(not(test))]

--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -13,11 +13,6 @@ pub fn dirt(ctx: RetProbeContext) -> u32 {
 }
 
 fn try_dirt(ctx: RetProbeContext) -> Result<u32, u32> {
-    // Get process information using BPF helpers
-    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
-    let pid = (pid_tgid >> 32) as u32;
-    let tgid = (pid_tgid & 0xFFFFFFFF) as u32;
-    
     // Get return value - handle the Option type
     let ret_val = match ctx.ret() {
         Some(val) => val,
@@ -25,12 +20,10 @@ fn try_dirt(ctx: RetProbeContext) -> Result<u32, u32> {
     };
     
     // Log detailed return information
-    info!(&ctx, "DIRT: vfs_unlink RETURN - PID: {}, TGID: {}, Return: {}", 
-          pid, tgid, ret_val);
+    info!(&ctx, "DIRT: vfs_unlink RETURN - Return: {}", ret_val);
     
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink RETURN - PID: %u, TGID: %u, Return: %d", 
-                    pid, tgid, ret_val);
+        bpf_printk!(b"DIRT: vfs_unlink RETURN - Return: %d", ret_val);
     }
     Ok(0)
 }
@@ -44,45 +37,13 @@ pub fn vfs_unlink_probe(ctx: ProbeContext) -> u32 {
 }
 
 fn try_vfs_unlink(ctx: ProbeContext) -> Result<u32, u32> {
-    // Get process information using BPF helpers
-    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
-    let pid = (pid_tgid >> 32) as u32;
-    let tgid = (pid_tgid & 0xFFFFFFFF) as u32;
-    
-    // Get process name
-    let mut comm: [u8; 16] = [0; 16];
-    let comm_result = unsafe { bpf_get_current_comm(comm.as_mut_ptr()) };
-    
-    // Convert comm array to string for logging
-    let comm_str = if comm_result == 0 {
-        // Find the first null byte to get the string length
-        let mut len = 0;
-        for (i, &byte) in comm.iter().enumerate() {
-            if byte == 0 {
-                len = i;
-                break;
-            }
-        }
-        core::str::from_utf8(&comm[..len]).unwrap_or("unknown")
-    } else {
-        "unknown"
-    };
-    
     // Log detailed entry information
-    info!(&ctx, "DIRT: vfs_unlink ENTRY - PID: {}, TGID: {}, Comm: {}", 
-          pid, tgid, comm_str);
+    info!(&ctx, "DIRT: vfs_unlink ENTRY - File deletion detected");
     
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink ENTRY - PID: %u, TGID: %u, Comm: %s", 
-                    pid, tgid, comm.as_ptr());
+        bpf_printk!(b"DIRT: vfs_unlink ENTRY - File deletion detected");
     }
     Ok(0)
-}
-
-// BPF helper function declarations
-unsafe extern "C" {
-    fn bpf_get_current_pid_tgid() -> u64;
-    fn bpf_get_current_comm(buf: *mut u8) -> i32;
 }
 
 #[cfg(not(test))]

--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -14,7 +14,7 @@ pub fn dirt(ctx: RetProbeContext) -> u32 {
 
 fn try_dirt(ctx: RetProbeContext) -> Result<u32, u32> {
     // Get process information using BPF helpers
-    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
     let pid = (pid_tgid >> 32) as u32;
     let tgid = (pid_tgid & 0xFFFFFFFF) as u32;
     
@@ -45,13 +45,13 @@ pub fn vfs_unlink_probe(ctx: ProbeContext) -> u32 {
 
 fn try_vfs_unlink(ctx: ProbeContext) -> Result<u32, u32> {
     // Get process information using BPF helpers
-    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
     let pid = (pid_tgid >> 32) as u32;
     let tgid = (pid_tgid & 0xFFFFFFFF) as u32;
     
     // Get process name
     let mut comm: [u8; 16] = [0; 16];
-    let comm_result = bpf_get_current_comm(comm.as_mut_ptr());
+    let comm_result = unsafe { bpf_get_current_comm(comm.as_mut_ptr()) };
     
     // Convert comm array to string for logging
     let comm_str = if comm_result == 0 {

--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -19,11 +19,19 @@ fn try_dirt(ctx: RetProbeContext) -> Result<u32, u32> {
         None => 0, // Default to 0 if no return value
     };
     
-    // Log detailed return information
-    info!(&ctx, "DIRT: vfs_unlink RETURN - Return: {}", ret_val);
+    // Get current task info for process details
+    let task = unsafe { aya_ebpf::helpers::bpf_get_current_task() };
+    let pid = unsafe { aya_ebpf::helpers::bpf_get_current_pid_tgid() };
+    let pid_num = (pid >> 32) as u32;
+    let tgid_num = (pid & 0xFFFFFFFF) as u32;
+    
+    // Log detailed return information with process details
+    info!(&ctx, "DIRT: vfs_unlink RETURN - PID: {}, TGID: {}, Task: {}, Return: {}", 
+          pid_num, tgid_num, task, ret_val);
     
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink RETURN - Return: %d", ret_val);
+        bpf_printk!(b"DIRT: vfs_unlink RETURN - PID: %u, TGID: %u, Return: %d", 
+                    pid_num, tgid_num, ret_val);
     }
     Ok(0)
 }
@@ -37,11 +45,19 @@ pub fn vfs_unlink_probe(ctx: ProbeContext) -> u32 {
 }
 
 fn try_vfs_unlink(ctx: ProbeContext) -> Result<u32, u32> {
-    // Log detailed entry information
-    info!(&ctx, "DIRT: vfs_unlink ENTRY - File deletion detected");
+    // Get current task info for process details
+    let task = unsafe { aya_ebpf::helpers::bpf_get_current_task() };
+    let pid = unsafe { aya_ebpf::helpers::bpf_get_current_pid_tgid() };
+    let pid_num = (pid >> 32) as u32;
+    let tgid_num = (pid & 0xFFFFFFFF) as u32;
+    
+    // Log detailed entry information with process details
+    info!(&ctx, "DIRT: vfs_unlink ENTRY - PID: {}, TGID: {}, Task: {}", 
+          pid_num, tgid_num, task);
     
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink ENTRY - File deletion detected");
+        bpf_printk!(b"DIRT: vfs_unlink ENTRY - PID: %u, TGID: %u", 
+                    pid_num, tgid_num);
     }
     Ok(0)
 }

--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -45,7 +45,7 @@ fn try_vfs_unlink(ctx: ProbeContext) -> Result<u32, u32> {
     if let Some(dentry_ptr) = dentry {
         let mut filename: [u8; 64] = [0; 64];
         let filename_result = unsafe { 
-            aya_ebpf::helpers::bpf_probe_read_kernel_str_bytes(&mut filename, (dentry_ptr + 32) as *const u8) 
+            aya_ebpf::helpers::bpf_probe_read_kernel_str_bytes((dentry_ptr + 32) as *const u8, &mut filename) 
         };
         
         match filename_result {

--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -13,17 +13,21 @@ pub fn dirt(ctx: RetProbeContext) -> u32 {
 }
 
 fn try_dirt(ctx: RetProbeContext) -> Result<u32, u32> {
-    // Get process information
-    let pid = bpf_get_current_pid_tgid() >> 32;
-    let tgid = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
+    // Get process information using BPF helpers
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid = (pid_tgid >> 32) as u32;
+    let tgid = (pid_tgid & 0xFFFFFFFF) as u32;
+    
+    // Get return value
+    let ret_val = ctx.ret();
     
     // Log detailed return information
-    info!(&ctx, "DIRT: vfs_unlink RETURN - PID: {}, TGID: {}, Return Code: {}", 
-          pid, tgid, ctx.ret());
+    info!(&ctx, "DIRT: vfs_unlink RETURN - PID: {}, TGID: {}, Return: {}", 
+          pid, tgid, ret_val);
     
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink RETURN - PID: %d, TGID: %d, Return: %d", 
-                    pid, tgid, ctx.ret());
+        bpf_printk!(b"DIRT: vfs_unlink RETURN - PID: %u, TGID: %u, Return: %d", 
+                    pid, tgid, ret_val);
     }
     Ok(0)
 }
@@ -37,58 +41,45 @@ pub fn vfs_unlink_probe(ctx: ProbeContext) -> u32 {
 }
 
 fn try_vfs_unlink(ctx: ProbeContext) -> Result<u32, u32> {
-    // Get process information
-    let pid = bpf_get_current_pid_tgid() >> 32;
-    let tgid = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
+    // Get process information using BPF helpers
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid = (pid_tgid >> 32) as u32;
+    let tgid = (pid_tgid & 0xFFFFFFFF) as u32;
     
-    // Get current task info
-    let task = bpf_get_current_task();
-    let comm = bpf_get_current_comm();
+    // Get process name
+    let mut comm: [u8; 16] = [0; 16];
+    let comm_result = bpf_get_current_comm(&mut comm);
+    
+    // Convert comm array to string for logging
+    let comm_str = if comm_result == 0 {
+        // Find the first null byte to get the string length
+        let mut len = 0;
+        for (i, &byte) in comm.iter().enumerate() {
+            if byte == 0 {
+                len = i;
+                break;
+            }
+        }
+        core::str::from_utf8(&comm[..len]).unwrap_or("unknown")
+    } else {
+        "unknown"
+    };
     
     // Log detailed entry information
-    info!(&ctx, "DIRT: vfs_unlink ENTRY - PID: {}, TGID: {}, Comm: {}, Task: {}", 
-          pid, tgid, comm, task);
+    info!(&ctx, "DIRT: vfs_unlink ENTRY - PID: {}, TGID: {}, Comm: {}", 
+          pid, tgid, comm_str);
     
     unsafe {
-        bpf_printk!(b"DIRT: vfs_unlink ENTRY - PID: %d, TGID: %d, Comm: %s", 
+        bpf_printk!(b"DIRT: vfs_unlink ENTRY - PID: %u, TGID: %u, Comm: %s", 
                     pid, tgid, &comm);
     }
     Ok(0)
 }
 
-// Helper functions to get process information
-#[inline(always)]
-fn bpf_get_current_pid_tgid() -> u64 {
-    unsafe {
-        let mut pid_tgid: u64 = 0;
-        bpf_get_current_pid_tgid(&mut pid_tgid as *mut u64 as *mut core::ffi::c_void);
-        pid_tgid
-    }
-}
-
-#[inline(always)]
-fn bpf_get_current_task() -> u64 {
-    unsafe {
-        let mut task: u64 = 0;
-        bpf_get_current_task(&mut task as *mut u64 as *mut core::ffi::c_void);
-        task
-    }
-}
-
-#[inline(always)]
-fn bpf_get_current_comm() -> [u8; 16] {
-    unsafe {
-        let mut comm: [u8; 16] = [0; 16];
-        bpf_get_current_comm(&mut comm as *mut u8 as *mut core::ffi::c_void, 16);
-        comm
-    }
-}
-
 // BPF helper function declarations
 extern "C" {
-    fn bpf_get_current_pid_tgid(pid_tgid: *mut core::ffi::c_void) -> u64;
-    fn bpf_get_current_task(task: *mut core::ffi::c_void) -> u64;
-    fn bpf_get_current_comm(buf: *mut core::ffi::c_void, size: u32) -> i32;
+    fn bpf_get_current_pid_tgid() -> u64;
+    fn bpf_get_current_comm(buf: *mut u8) -> i32;
 }
 
 #[cfg(not(test))]

--- a/dirt/dirt/src/main.rs
+++ b/dirt/dirt/src/main.rs
@@ -5,12 +5,17 @@ use tokio::signal;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Set log level to see all messages including debug
-    env_logger::Builder::from_default_env()
-        .filter_level(log::LevelFilter::Debug)
+    // Set default log level to Info if RUST_LOG is not set
+    let env = env_logger::Env::default().default_filter_or("info");
+    env_logger::Builder::from_env(env)
+        .filter_level(log::LevelFilter::Info)
+        .format_timestamp_millis()
+        .format_module_path(false)
+        .format_target(false)
         .init();
 
-    info!("Starting eBPF program...");
+    info!("=== DIRT eBPF File Deletion Monitor Starting ===");
+    info!("Monitoring file deletions via vfs_unlink system calls");
 
     // Bump the memlock rlimit. This is needed for older kernels that don't use the
     // new memcg based accounting, see https://lwn.net/Articles/837122/
@@ -20,48 +25,53 @@ async fn main() -> anyhow::Result<()> {
     };
     let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
     if ret != 0 {
-        debug!("remove limit on locked memory failed, ret is: {ret}");
+        debug!("DIRT: Failed to remove limit on locked memory, ret: {ret}");
+    } else {
+        debug!("DIRT: Successfully set memlock limit to infinity");
     }
 
     // This will include your eBPF object file as raw bytes at compile-time and load it at
     // runtime. This approach is recommended for most real-world use cases. If you would
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
-    info!("Loading eBPF program...");
+    info!("DIRT: Loading eBPF program...");
     let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
         env!("OUT_DIR"),
         "/dirt"
     )))?;
     
-    info!("Initializing eBPF logger...");
+    info!("DIRT: Initializing eBPF logger...");
     if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
         // This can happen if you remove all log statements from your eBPF program.
-        warn!("failed to initialize eBPF logger: {e}");
+        warn!("DIRT: Failed to initialize eBPF logger: {e}");
     } else {
-        info!("eBPF logger initialized successfully");
+        info!("DIRT: eBPF logger initialized successfully");
     }
     
     // Attach the existing kretprobe
-    info!("Loading and attaching kretprobe 'dirt'...");
+    info!("DIRT: Loading and attaching kretprobe 'dirt'...");
     let dirt_program: &mut KProbe = ebpf.program_mut("dirt").unwrap().try_into()?;
     dirt_program.load()?;
     dirt_program.attach("vfs_unlink", 0)?;
-    info!("kretprobe 'dirt' attached successfully to vfs_unlink");
+    info!("DIRT: kretprobe 'dirt' attached successfully to vfs_unlink");
     
     // Attach the new kprobe for vfs_unlink
-    info!("Loading and attaching kprobe 'vfs_unlink_probe'...");
+    info!("DIRT: Loading and attaching kprobe 'vfs_unlink_probe'...");
     let vfs_unlink_program: &mut KProbe = ebpf.program_mut("vfs_unlink_probe").unwrap().try_into()?;
     vfs_unlink_program.load()?;
     vfs_unlink_program.attach("vfs_unlink", 0)?;
-    info!("kprobe 'vfs_unlink_probe' attached successfully to vfs_unlink");
+    info!("DIRT: kprobe 'vfs_unlink_probe' attached successfully to vfs_unlink");
 
-    info!("Both probes are active. Try deleting a file to see output!");
-    info!("Example: 'touch /tmp/test && rm /tmp/test' in another terminal");
+    info!("DIRT: === Monitoring Active ===");
+    info!("DIRT: Both probes are now active and monitoring file deletions");
+    info!("DIRT: Try deleting a file to see detailed output!");
+    info!("DIRT: Example: 'touch /tmp/test && rm /tmp/test' in another terminal");
+    info!("DIRT: You should see both entry and exit logs for each deletion");
     
     let ctrl_c = signal::ctrl_c();
-    println!("Waiting for Ctrl-C...");
+    println!("DIRT: Waiting for Ctrl-C to stop monitoring...");
     ctrl_c.await?;
-    println!("Exiting...");
+    println!("DIRT: Shutting down file deletion monitor...");
 
     Ok(())
 }

--- a/dirt/dirt/src/main.rs
+++ b/dirt/dirt/src/main.rs
@@ -16,6 +16,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!("=== DIRT eBPF File Deletion Monitor Starting ===");
     info!("Monitoring file deletions via vfs_unlink system calls");
+    info!("You'll see detailed process information for each deletion");
 
     // Bump the memlock rlimit. This is needed for older kernels that don't use the
     // new memcg based accounting, see https://lwn.net/Articles/837122/
@@ -64,9 +65,10 @@ async fn main() -> anyhow::Result<()> {
 
     info!("DIRT: === Monitoring Active ===");
     info!("DIRT: Both probes are now active and monitoring file deletions");
+    info!("DIRT: Each deletion will show: PID, TGID, Task pointer, and return code");
     info!("DIRT: Try deleting a file to see detailed output!");
     info!("DIRT: Example: 'touch /tmp/test && rm /tmp/test' in another terminal");
-    info!("DIRT: You should see both entry and exit logs for each deletion");
+    info!("DIRT: You can use 'ps -p <PID>' to see which process is deleting files");
     
     let ctrl_c = signal::ctrl_c();
     println!("DIRT: Waiting for Ctrl-C to stop monitoring...");


### PR DESCRIPTION
Improve file deletion monitor logging to remove `RUST_LOG` requirement and provide more detailed, distinguishable output.

This PR sets the default log level to `info` in `main.rs` so `RUST_LOG=info` is no longer needed. It also enhances eBPF logs in `dirt-ebpf/src/main.rs` to include PID, TGID, process name (comm), and syscall return codes for better detail. All logs are now prefixed with "DIRT:" to easily distinguish them from other system output. Compilation errors related to BPF helper function calls and `aya-log` formatting were also resolved.