### PR TITLE
feat: Add filename to UnlinkEvent and JSON output

### DIFF
--- a/dirt/dirt-common/src/lib.rs
+++ b/dirt/dirt-common/src/lib.rs
@@ -10,7 +10,6 @@ pub enum EventType {
     FExit,
 }
 
-#[cfg_attr(feature = "user", derive(Serialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct UnlinkEvent {
     pub event_type: EventType,
@@ -18,4 +17,5 @@ pub struct UnlinkEvent {
     pub tgid: u32,
     pub target_dev: u32,
     pub ret_val: i32,
+    pub filename: [u8; 256],
 }

--- a/dirt/dirt-ebpf/src/main.rs
+++ b/dirt/dirt-ebpf/src/main.rs
@@ -5,16 +5,69 @@ mod vmlinux;
 
 use aya_ebpf::{
     macros::{map, tracepoint},
-    maps::{Array, PerfEventArray},
+    maps::{Array, HashMap, PerfEventArray},
     programs::TracePointContext,
 };
 use dirt_common::{EventType, UnlinkEvent};
+
+const MAX_FILENAME_LEN: usize = 256;
 
 #[map]
 static TARGET_DEV: Array<u32> = Array::with_max_entries(1, 0);
 
 #[map]
 static EVENTS: PerfEventArray<UnlinkEvent> = PerfEventArray::new(0);
+
+#[map]
+static FILENAMES: HashMap<u32, [u8; MAX_FILENAME_LEN]> = HashMap::with_max_entries(1024, 0);
+
+#[tracepoint]
+pub fn sys_enter_unlink(ctx: TracePointContext) -> u32 {
+    match try_sys_enter_unlink(ctx) {
+        Ok(ret) => ret,
+        Err(_) => 1,
+    }
+}
+
+fn try_sys_enter_unlink(ctx: TracePointContext) -> Result<u32, i64> {
+    let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
+    let tgid = (pid_tgid >> 32) as u32;
+
+    let pathname_ptr: u64 = unsafe { ctx.read_at(16)? };
+    let mut filename = [0u8; MAX_FILENAME_LEN];
+    let res =
+        unsafe { aya_ebpf::helpers::bpf_probe_read_user_str_bytes(pathname_ptr as *const u8, &mut filename) };
+
+    if res.is_ok() {
+        FILENAMES.insert(&tgid, &filename, 0)?;
+    }
+
+    Ok(0)
+}
+
+#[tracepoint]
+pub fn sys_enter_unlinkat(ctx: TracePointContext) -> u32 {
+    match try_sys_enter_unlinkat(ctx) {
+        Ok(ret) => ret,
+        Err(_) => 1,
+    }
+}
+
+fn try_sys_enter_unlinkat(ctx: TracePointContext) -> Result<u32, i64> {
+    let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
+    let tgid = (pid_tgid >> 32) as u32;
+
+    let pathname_ptr: u64 = unsafe { ctx.read_at(24)? };
+    let mut filename = [0u8; MAX_FILENAME_LEN];
+    let res =
+        unsafe { aya_ebpf::helpers::bpf_probe_read_user_str_bytes(pathname_ptr as *const u8, &mut filename) };
+
+    if res.is_ok() {
+        FILENAMES.insert(&tgid, &filename, 0)?;
+    }
+
+    Ok(0)
+}
 
 #[tracepoint]
 pub fn sys_exit_unlink(ctx: TracePointContext) -> u32 {
@@ -25,35 +78,32 @@ pub fn sys_exit_unlink(ctx: TracePointContext) -> u32 {
 }
 
 fn try_sys_exit_unlink(ctx: TracePointContext) -> Result<u32, u32> {
-    // Only process successful unlinks (ret == 0)
-    let ret_val = unsafe { 
-        match ctx.read_at::<i64>(16) {
-            Ok(val) => val as i32,
-            Err(_) => return Err(1),
-        }
-    };
-    
+    let ret_val = unsafe { ctx.read_at::<i64>(16).map(|val| val as i32).unwrap_or(-1) };
     if ret_val != 0 {
-        return Ok(0); // Skip failed unlinks
+        return Ok(0);
     }
-
-    let target_dev = match TARGET_DEV.get(0) {
-        Some(val) => *val,
-        None => return Err(1),
-    };
 
     let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
     let tgid = (pid_tgid >> 32) as u32;
-    let pid = pid_tgid as u32;
 
-    let event = UnlinkEvent {
-        event_type: EventType::FExit,
-        pid,
-        tgid,
-        target_dev,
-        ret_val,
-    };
-    EVENTS.output(&ctx, &event, 0);
+    if let Some(filename) = unsafe { FILENAMES.get(&tgid) } {
+        let target_dev = match TARGET_DEV.get(0) {
+            Some(val) => *val,
+            None => return Err(1),
+        };
+
+        let pid = pid_tgid as u32;
+        let event = UnlinkEvent {
+            event_type: EventType::FExit,
+            pid,
+            tgid,
+            target_dev,
+            ret_val,
+            filename: *filename,
+        };
+        EVENTS.output(&ctx, &event, 0);
+        FILENAMES.remove(&tgid).ok();
+    }
 
     Ok(0)
 }
@@ -67,38 +117,36 @@ pub fn sys_exit_unlinkat(ctx: TracePointContext) -> u32 {
 }
 
 fn try_sys_exit_unlinkat(ctx: TracePointContext) -> Result<u32, u32> {
-    // Only process successful unlinks (ret == 0)
-    let ret_val = unsafe { 
-        match ctx.read_at::<i64>(16) {
-            Ok(val) => val as i32,
-            Err(_) => return Err(1),
-        }
-    };
-    
+    let ret_val = unsafe { ctx.read_at::<i64>(16).map(|val| val as i32).unwrap_or(-1) };
     if ret_val != 0 {
-        return Ok(0); // Skip failed unlinks
+        return Ok(0);
     }
-
-    let target_dev = match TARGET_DEV.get(0) {
-        Some(val) => *val,
-        None => return Err(1),
-    };
 
     let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
     let tgid = (pid_tgid >> 32) as u32;
-    let pid = pid_tgid as u32;
 
-    let event = UnlinkEvent {
-        event_type: EventType::FExit,
-        pid,
-        tgid,
-        target_dev,
-        ret_val,
-    };
-    EVENTS.output(&ctx, &event, 0);
+    if let Some(filename) = unsafe { FILENAMES.get(&tgid) } {
+        let target_dev = match TARGET_DEV.get(0) {
+            Some(val) => *val,
+            None => return Err(1),
+        };
+
+        let pid = pid_tgid as u32;
+        let event = UnlinkEvent {
+            event_type: EventType::FExit,
+            pid,
+            tgid,
+            target_dev,
+            ret_val,
+            filename: *filename,
+        };
+        EVENTS.output(&ctx, &event, 0);
+        FILENAMES.remove(&tgid).ok();
+    }
 
     Ok(0)
 }
+
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {


### PR DESCRIPTION
This commit modifies the eBPF program to capture the filename during `unlink` and `unlinkat` syscalls.

- The `UnlinkEvent` struct in `dirt-common` is updated to include a `filename` field.
- The eBPF program in `dirt-ebpf` now uses `sys_enter` and `sys_exit` tracepoints to capture the filename. A `HashMap` is used to pass the filename from the enter to the exit probe.
- The user-space application in `dirt` is updated to load the new tracepoints and to correctly process the filename from a byte array to a String for JSON serialization.